### PR TITLE
Avoid working with HTML strings

### DIFF
--- a/components/Settings.jsx
+++ b/components/Settings.jsx
@@ -1,10 +1,9 @@
-const { React, getModuleByDisplayName } = require('powercord/webpack')
+const { React } = require('powercord/webpack')
 const { SelectInput, TextInput } = require('powercord/components/settings')
+const { Spinner } = require('powercord/components')
+const { sleep } = require('powercord/util')
 const ShikiHighlighter = require('./ShikiHighlighter')
 const previewsData = require('../previews')
-
-const wait = ms => new Promise(res => setTimeout(res, ms))
-const Spinner = getModuleByDisplayName('Spinner', false)
 
 const ERROR_COLOR = '#f04747'
 const CUSTOM_THEME_ISSUES = [
@@ -37,7 +36,7 @@ module.exports = class Settings extends React.PureComponent {
     return 0
   }
   padPromise (promise) { // https://i.imgur.com/G7Qmfxj.png
-    return Promise.all([promise, wait(LOAD_PADDING)])
+    return Promise.all([promise, sleep(LOAD_PADDING)])
   }
 
   render () {
@@ -48,6 +47,7 @@ module.exports = class Settings extends React.PureComponent {
       loadHighlighter,
       getHighlighter,
       getLangName,
+      refreshCodeblocks
     } = this.props
 
     const previews = previewsData.map(data => (
@@ -92,6 +92,7 @@ module.exports = class Settings extends React.PureComponent {
             this.setState({ isThemeLoading: true })
             this.padPromise(loadHighlighter()).then(() => {
               this.setState({ isThemeLoading: false })
+              refreshCodeblocks()
             })
           }}
           options={shiki.BUNDLED_THEMES.map(theme => ({
@@ -113,6 +114,7 @@ module.exports = class Settings extends React.PureComponent {
               updateSetting('custom-theme', value)
               this.padPromise(loadHighlighter()).then(() => {
                 this.setState({ isThemeLoading: false })
+                refreshCodeblocks()
               })
               this.setState({
                 isThemeLoading: true,

--- a/components/ShikiHighlighter.jsx
+++ b/components/ShikiHighlighter.jsx
@@ -6,12 +6,6 @@ module.exports = class ShikiHighlighter extends React.PureComponent {
     copyCooldown: false
   }
 
-  text2DOM (text) {
-    const template = document.createElement('template')
-    template.innerHTML = text
-    return template.content.firstChild
-  }
-
   onCopyBtnClick () {
     if (this.state.copyCooldown) return
 

--- a/components/ShikiHighlighter.jsx
+++ b/components/ShikiHighlighter.jsx
@@ -39,32 +39,28 @@ module.exports = class ShikiHighlighter extends React.PureComponent {
 
     const highlighter = getHighlighter()
 
-    let html
+    let tokens
     try {
-      html = highlighter.codeToHtml(content, lang)
+      tokens = highlighter.codeToThemedTokens(content, lang)
     } catch (error) {
-      html = highlighter.codeToHtml(content)
+      tokens = highlighter.codeToThemedTokens(content)
     }
 
-    const pre = this.text2DOM(html)
     const langName = getLangName(lang)
     const theme = highlighter.getTheme()._theme
     const plainColor = theme.fg
     const accentBgColor = theme.colors['statusBar.background'] || '#007BC8'
     const accentFgColor = theme.colors['statusBar.foreground'] || '#FFF'
+    const backgroundColor = theme.colors['editor.background'] || 'var(--background-secondary)'
 
-    const lineSpans = [...pre.firstChild.children]
-    let lines
-    if (langName || lineSpans.length !== 1) {
-      lines = lineSpans.map(line => line.innerHTML)
-    } else {
-      lines = lineSpans[0].firstChild.innerHTML.split('\n').map(line => `<span style="color: ${plainColor}">${line}</span>`)
-    }
-
-    const codeTableRows = lines.map((line, i) => (
+    const codeTableRows = tokens.map((line, i) => (
       <tr>
         <td style={{ color: plainColor }}>{i + 1}</td>
-        <td dangerouslySetInnerHTML={{ __html: line }}></td>
+        <td>
+          {line.map(({ content, color }) => (
+            <span style={{ color }}>{content}</span>
+          ))}
+        </td>
       </tr>
     ))
 
@@ -73,7 +69,7 @@ module.exports = class ShikiHighlighter extends React.PureComponent {
     if (isPreview) preClassName += ' vpc-shiki-preview'
 
     return (
-      <pre className={preClassName} style={{ backgroundColor: pre.style.backgroundColor }}>
+      <pre className={preClassName} style={{ backgroundColor }}>
         <code>
           {langName && <div className="vpc-shiki-lang" style={{ color: plainColor }}>{langName}</div>}
           <table className="vpc-shiki-table">

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const { Plugin } = require('powercord/entities')
 const { React, getModule } = require('powercord/webpack')
 const { inject, uninject } = require('powercord/injector')
 const { getReactInstance } = require('powercord/util')
-const { resolve } = require('path')
+
 const Settings = require('./components/Settings.jsx')
 const ShikiHighlighter = require('./components/ShikiHighlighter.jsx')
 const languages = require('./languages')
@@ -14,18 +14,19 @@ shiki.setCDN(CDN_PATH)
 
 module.exports = class ShikiCodeblocks extends Plugin {
   startPlugin () {
-    this.loadStylesheet(resolve(__dirname, 'style.css'))
+    this.loadStylesheet('style.css')
 
     powercord.api.settings.registerSettings('vpc-shiki', {
       category: this.entityID,
       label: 'Shiki Codeblocks',
-      render: () => React.createElement(Settings, {
-        getSetting: this.settings.get,
-        updateSetting: this.settings.set,
+      render: ({ getSetting, updateSetting }) => React.createElement(Settings, {
+        getSetting,
+        updateSetting,
         shiki,
         loadHighlighter: this.loadHighlighter.bind(this),
         getHighlighter: this.getHighlighter.bind(this),
         getLangName: this.getLangName,
+        refreshCodeblocks: () => this.forceUpdate()
       })
     })
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Shiki Codeblock",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Highlight codeblocks with shiki because its pretty hot",
   "author": "Vap0r1ze",
   "license": "MIT"


### PR DESCRIPTION
This replaces the handling of the highlighted html markup to code tokens, which is much safer and prevents using `__dangerouslySetInnerHTML`.

I also cleaned up some things I've noticed on my way and made the settings trigger a force-update, so theme changes apply immediately when you go back in chat.