### PR TITLE
Fix erroring out on start of channel

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,6 @@ module.exports = class ShikiCodeblocks extends Plugin {
     return languages.find(lang => [...(lang.aliases || []), lang.id].includes(id))
   }
   forceUpdate () {
-    document.querySelectorAll('[id^="chat-messages-"]').forEach(e => getReactInstance(e).memoizedProps.onMouseMove())
+    document.querySelectorAll('[id^="chat-messages-"]').forEach(e => getReactInstance(e)?.memoizedProps?.onMouseMove?.call())
   }
 }

--- a/index.js
+++ b/index.js
@@ -109,6 +109,6 @@ module.exports = class ShikiCodeblocks extends Plugin {
     return languages.find(lang => [...(lang.aliases || []), lang.id].includes(id))
   }
   forceUpdate () {
-    document.querySelectorAll('[id^="chat-messages-"]').forEach(e => getReactInstance(e)?.memoizedProps?.onMouseMove?.call())
+    document.querySelectorAll('[id^="chat-messages-"]').forEach(e => getReactInstance(e)?.memoizedProps?.onMouseMove?.())
   }
 }


### PR DESCRIPTION
In DMs, it appears it throws an error if it's the start of a channel (may happen on server channels too?). This only produces an error in console, but only if `forceUpdate` is called which it is on startup, but it's something to fix up.
This ensures it won't produce an error in the future, but I'm sure a simple css change would've worked too :) up to you on how you wanna handle this error.
![DiscordDevelopment_FlYcCHqs7m](https://user-images.githubusercontent.com/49841131/115761642-da740c80-a3a2-11eb-9f74-976982973c7c.png)
![DiscordDevelopment_43I2v7DmYk](https://user-images.githubusercontent.com/49841131/115761647-dc3dd000-a3a2-11eb-938f-9a92f03eb6a6.png)
![DiscordDevelopment_lI00Guxo6c](https://user-images.githubusercontent.com/49841131/115761651-de079380-a3a2-11eb-9e8a-82a34777bcb4.png)
