### PR TITLE
Add Language: GDScript

### DIFF
--- a/languages/GDScript.tmLanguage.json
+++ b/languages/GDScript.tmLanguage.json
@@ -1,0 +1,338 @@
+{
+  "fileTypes": [
+    "gd"
+  ],
+  "scopeName": "source.gdscript",
+  "name": "GDScript",
+  "patterns": [
+    { "include": "#base_expression" },
+    { "include": "#logic_op" },
+    { "include": "#compare_op" },
+    { "include": "#arithmetic_op" },
+    { "include": "#assignment_op" },
+    { "include": "#keywords" },
+    { "include": "#self" },
+    { "include": "#const_def" },
+    { "include": "#type_declear"},
+    { "include": "#class_def" },
+    { "include": "#class_name"},
+    { "include": "#builtin_func" },
+    { "include": "#builtin_classes" },
+    { "include": "#const_vars" },
+    { "include": "#class_new"},
+    { "include": "#class_is"},
+    { "include": "#class_enum"},
+    { "include": "#function-declaration" },
+    { "include": "#function-return-type" },
+    { "include": "#any-method" },
+    { "include": "#any-property" },
+    { "include": "#extends" },
+    { "include": "#pascal_case_class" }
+  ],
+  "repository": {
+    "comment": {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.comment.number-sign.gdscript"
+        }
+      },
+      "match": "(#).*$\\n?",
+      "name": "comment.line.number-sign.gdscript"
+    },
+    "strings": {
+      "patterns": [{
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {  "name": "constant.character.escape.untitled",
+                "match": "\\."
+            }
+          ],
+          "name": "string.quoted.double.gdscript"
+        },
+        {
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            {  "name": "constant.character.escape.untitled",
+                "match": "\\."
+            }
+          ],
+          "name": "string.quoted.single.gdscript"
+        },
+        {
+          "begin": "@\"",
+          "end": "\"",
+          "patterns": [
+            {  "name": "constant.character.escape.untitled",
+                "match": "\\."
+            }
+          ],
+          "name": "string.nodepath.gdscript"
+        }
+      ]
+    },
+    "self": {
+      "match": "\\bself\\b",
+      "name": "variable.language.gdscript"
+    },
+    "base_expression": {
+      "patterns": [
+        { "include": "#strings"},
+        { "include": "#comment"},
+        { "include": "#letter"},
+        { "include": "#numbers"},
+        { "include": "#line-continuation"}
+      ]
+    },
+    "logic_op": {
+      "match": "\\b(and|or|not)\\b",
+      "name": "keyword.operator.logical.gdscript"
+    },
+    "compare_op": {
+      "match": "<=|>=|==|<|>|!=",
+      "name": "keyword.operator.comparison.gdscript"
+    },
+    "arithmetic_op": {
+      "match": "\\+=|-=|\\*=|/=|%=|&=|\\|=|\\*|/|%|\\+|-|<<|>>|&|\\||\\^|~",
+      "name": "keyword.operator.arithmetic.gdscript"
+    },
+    "assignment_op": {
+      "match": "=",
+      "name": "keyword.operator.assignment.gdscript"
+    },
+
+    "keywords": {
+      "match": "\\b(?i:if|elif|else|for|while|break|continue|pass|return|match|func|class|class_name|extends|is|in|onready|tool|static|export|setget|const|var|as|void|enum|preload|assert|yield|signal|breakpoint|rpc|sync|master|puppet|slave|remotesync|mastersync|puppetsync)\\b",
+      "name": "keyword.language.gdscript"
+    },
+    "letter": {
+        "match": "\\b(?i:true|false|null)\\b",
+        "name": "constant.language.gdscript"
+    },
+    "numbers": {
+      "patterns": [{
+          "match": "\\b(?i:0x\\h*)\\b",
+          "name": "constant.numeric.integer.hexadecimal.gdscript"
+        },
+        {
+          "match": "\\b(?i:(\\d+\\.\\d*(e[\\-\\+]?\\d+)?))\\b",
+          "name": "constant.numeric.float.gdscript"
+        },
+        {
+          "match": "\\b(?i:(\\.\\d+(e[\\-\\+]?\\d+)?))\\b",
+          "name": "constant.numeric.float.gdscript"
+        },
+        {
+          "match": "\\b(?i:(\\d+e[\\-\\+]?\\d+))\\b",
+          "name": "constant.numeric.float.gdscript"
+        },
+        {
+          "match": "\\b\\d+\\b",
+          "name": "constant.numeric.integer.gdscript"
+        }
+      ]
+    },
+    "const_def": {
+      "match": "\\b(?i:(const))\\s+([a-zA-Z_][a-zA-Z_0-9]*)",
+      "captures": {
+        "1": { "name": "storage.type.const.gdscript" },
+        "2": { "name": "constant.language.gdscript" }
+      }
+    },
+    "var_def": {
+      "match": "\\b(?i:(var))\\s+([a-zA-Z_][a-zA-Z_0-9]*)",
+      "captures": {
+        "1": { "name": "storage.type.var.gdscript" },
+        "2": { "name": "variable.language.gdscript" }
+      }
+    },
+    "type_declear": {
+      "match": "\\:\\s*([a-zA-Z_][a-zA-Z_0-9]*)",
+      "captures": {
+        "1": { "name": "entity.name.type.class.gdscript" }
+      }
+    },
+    "function-return-type": {
+      "match": "\\)\\s*\\-\\>\\s*([a-zA-Z_][a-zA-Z_0-9]*)\\s*\\:",
+      "captures": {
+        "1": { "name": "entity.name.type.class.gdscript" }
+      }
+    },
+    "class_def": {
+      "captures": {
+        "1": { "name": "entity.name.type.class.gdscript" },
+        "2": { "name": "class.other.gdscript" }
+      },
+      "match": "(?<=^class)\\s+([a-zA-Z_]\\w*)\\s*(?=:)"
+    },
+    "class_new": {
+      "captures": {
+        "1": { "name": "entity.name.type.class.gdscript" },
+        "2": { "name": "storage.type.new.gdscript" }
+      },
+      "match": "\\b([a-zA-Z_][a-zA-Z_0-9]*).(new)\\("
+    },
+    "class_is": {
+      "captures": {
+        "1": { "name": "storage.type.is.gdscript" },
+        "2": { "name": "entity.name.type.class.gdscript" }
+      },
+      "match": "\\s+(is)\\s+([a-zA-Z_][a-zA-Z_0-9]*)"
+    },
+    "class_enum": {
+      "captures": {
+        "1": { "name": "entity.name.type.class.gdscript" },
+        "2": { "name": "constant.language.gdscript" }
+      },
+      "match": "\\b([A-Z][a-zA-Z_0-9]*)\\.([A-Z_0-9]+)"
+    },
+    "class_name": {
+      "captures": {
+        "1": { "name": "entity.name.type.class.gdscript" },
+        "2": { "name": "class.other.gdscript" }
+      },
+      "match": "(?<=class_name)\\s+([a-zA-Z_][a-zA-Z_0-9]*(\\.([a-zA-Z_][a-zA-Z_0-9]*))?)"
+    },
+    "extends": {
+      "match": "(?<=extends)\\s+[a-zA-Z_][a-zA-Z_0-9]*(\\.([a-zA-Z_][a-zA-Z_0-9]*))?",
+      "name": "entity.other.inherited-class.gdscript"
+    },
+    "builtin_func": {
+      "match": "(?<![^.]\\.|:)\\b(sin|cos|tan|sinh|cosh|tanh|asin|acos|atan|atan2|sqrt|fmod|fposmod|floor|ceil|round|abs|sign|pow|log|exp|is_nan|is_inf|ease|decimals|stepify|lerp|dectime|randomize|randi|randf|rand_range|seed|rand_seed|deg2rad|rad2deg|linear2db|db2linear|max|min|clamp|nearest_po2|weakref|funcref|convert|typeof|type_exists|char|str|print|printt|prints|printerr|printraw|var2str|str2var|var2bytes|bytes2var|range|load|inst2dict|dict2inst|hash|Color8|print_stack|instance_from_id|preload|yield|assert)\\b(?=(\\()([^)]*)(\\)))",
+      "name": "support.function.builtin.gdscript"
+    },
+    "builtin_classes": {
+      "match": "(?<![^.]\\.|:)\\b(Vector2|Vector3|Color|Rect2|Array|Basis|Dictionary|Plane|Quat|RID|Rect3|Transform|Transform2D|AABB|String|Color|NodePath|RID|Object|Dictionary|Array|PoolByteArray|PoolIntArray|PoolRealArray|PoolStringArray|PoolVector2Array|PoolVector3Array|PoolColorArray)\\b",
+      "name": "support.class.library.gdscript"
+    },
+    "const_vars": {
+      "match": "\\b([A-Z_0-9]+)\\b",
+      "name": "constant.language.gdscript"
+    },
+    "function-declaration": {
+      "name": "meta.function.gdscript",
+      "begin": "(?x)\n  \\s*\n  (?:\\b(static) \\s+)? \\b(func|signal)\\s+\n    (?=\n      [[:alpha:]_][[:word:]]* \\s* \\(\n    )\n",
+      "end": "(:|(?=[#'\"\\n]))",
+      "beginCaptures": {
+        "1": { "name": "storage.type.function.static.gdscript" },
+        "2": { "name": "storage.type.function.gdscript" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.section.function.begin.gdscript" }
+      },
+      "patterns": [
+        { "include": "#function-def-name" },
+        { "include": "#parameters" },
+        { "include": "#line-continuation" },
+        { "include": "#return-annotation" }
+      ]
+    },
+    "function-def-name": {
+      "patterns": [
+        {
+          "name": "entity.name.function.gdscript",
+          "match": "(?x)\n  \\b ([[:alpha:]_]\\w*) \\b\n"
+        }
+      ]
+    },
+    "parameters": {
+      "name": "meta.function.parameters.gdscript",
+      "begin": "(\\()",
+      "end": "(\\))",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.parameters.begin.gdscript" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.parameters.end.gdscript" }
+      },
+      "patterns": [{
+          "name": "keyword.operator.unpacking.parameter.gdscript",
+          "match": "(\\*\\*|\\*)"
+        },
+        { "include": "#parameter-special" },
+        {
+          "match": "(?x)\n  ([[:alpha:]_]\\w*)\n    \\s* (?: (,) | (?=[)#\\n=]))\n",
+          "captures": {
+            "1": { "name": "variable.parameter.function.language.gdscript" },
+            "2": { "name": "punctuation.separator.parameters.gdscript" }
+          }
+        },
+        { "include": "#comment" },
+        { "include": "#loose-default"},
+        { "include": "#annotated-parameter" }
+      ]
+    },
+    "any-method": {
+      "match": "\\b([A-Za-z_]\\w*)\\b(?=\\s*(?:[(]))",
+      "name": "support.function.any-method.gdscript"
+    },
+    "any-property": {
+      "match": "(?<=[^.]\\.)\\b([A-Za-z_]\\w*)\\b(?![(])",
+      "name": "variable.other.property.gdscript"
+    },
+    "parameter-special": {
+      "match": "(?x)\n  \\b ((self)|(cls)) \\b \\s*(?:(,)|(?=\\)))\n",
+      "captures": {
+        "1": { "name": "variable.parameter.function.language.gdscript" },
+        "2": { "name": "variable.parameter.function.language.special.self.gdscript" },
+        "3": { "name": "variable.parameter.function.language.special.cls.gdscript" },
+        "4": { "name": "punctuation.separator.parameters.gdscript" }
+      }
+    },
+    "loose-default": {
+      "begin": "(=)",
+      "end": "(,)|(?=\\))",
+      "beginCaptures": {
+        "1": { "name": "keyword.operator.gdscript" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.separator.parameters.gdscript" }
+      },
+      "patterns": [
+          { "include": "#base_expression"}
+      ]
+    },
+    "annotated-parameter": {
+      "begin": "(?x)\n  \\b\n  ([[:alpha:]_]\\w*) \\s* (:)\n",
+      "end": "(,)|(?=\\))",
+      "beginCaptures": {
+        "1": { "name": "variable.parameter.function.language.gdscript" },
+        "2": { "name": "punctuation.separator.annotation.gdscript" }
+      },
+      "endCaptures": {
+        "1": { "name": "punctuation.separator.parameters.gdscript" }
+      },
+      "patterns": [
+        { "name": "keyword.operator.assignment.gdscript", "match": "=(?!=)"}
+      ]
+    },
+    "line-continuation": {
+      "patterns": [
+        {
+          "match": "(\\\\)\\s*(\\S.*$\\n?)",
+          "captures": {
+            "1": { "name": "punctuation.separator.continuation.line.gdscript" },
+            "2": { "name": "invalid.illegal.line.continuation.gdscript" }
+          }
+        },
+        {
+          "begin": "(\\\\)\\s*$\\n?",
+          "end": "(?x)\n  (?=^\\s*$)\n  |\n  (?! (\\s* [rR]? (\\'\\'\\'|\\\"\\\"\\\"|\\'|\\\"))\n      |\n      (\\G $)  (?# '\\G' is necessary for ST)\n  )\n",
+          "beginCaptures": {
+            "1": { "name": "punctuation.separator.continuation.line.gdscript" }
+          },
+          "patterns": [
+            { "include": "#base_expression" }
+          ]
+        }
+      ]
+    },
+    "pascal_case_class": {
+      "captures": {
+        "1": { "name": "entity.name.type.class.gdscript" }
+      },
+      "match": "\\b([A-Z][a-zA-Z_0-9]*)\\b"
+    }
+  }
+}

--- a/languages/index.js
+++ b/languages/index.js
@@ -206,6 +206,12 @@ module.exports = [
     grammar: loadJSON('gnuplot.tmLanguage.json')
   },
   {
+    name: 'GDScript',
+    id: 'gdscript',
+    scopeName: 'source.gdscript',
+    grammar: loadJSON('GDScript.tmLanguage.json')
+  },
+  {
     name: 'Go',
     id: 'go',
     devicon: 'go-plain',

--- a/languages/index.js
+++ b/languages/index.js
@@ -209,7 +209,8 @@ module.exports = [
     name: 'GDScript',
     id: 'gdscript',
     scopeName: 'source.gdscript',
-    grammar: loadJSON('GDScript.tmLanguage.json')
+    grammar: loadJSON('GDScript.tmLanguage.json'),
+    aliases: ['godot', 'gds', 'gd']
   },
   {
     name: 'Go',


### PR DESCRIPTION
Title. Adds support for GDScript, the scripting language used with Godot Engine.

Updates index.js with an entry that calls GDScript.tmLanguage.json, adds some aliases for quality of life.